### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Install it from the PowerShell Gallery:
 
 ```pwsh
 Install-Module opCompleter
+Import-Module opCompleter
 ```
 
 ![op TabComplete](/images/opTabCompletion.png)


### PR DESCRIPTION
The completer only registers on module import. Not sure if there's a way to get a module to load when a native app is used.